### PR TITLE
feat: update deps, fix build, prefetch projects on hover

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
       all-dependencies:
         patterns:

--- a/package.json
+++ b/package.json
@@ -14,26 +14,26 @@
     "canvas-confetti": "^1.9.4",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "framer-motion": "^12.35.0",
+    "framer-motion": "^12.38.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-icons": "^5.6.0",
-    "react-intl": "^8.1.3",
-    "react-router-dom": "^7.13.1",
+    "react-intl": "^10.1.1",
+    "react-router-dom": "^7.13.2",
     "sonner": "^2.0.7",
     "web-haptics": "^0.0.6"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.1",
+    "@tailwindcss/vite": "^4.2.2",
     "@types/canvas-confetti": "^1.9.0",
-    "@types/node": "^25.3.3",
+    "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vercel/node": "^5.6.10",
-    "@vitejs/plugin-react": "^5.1.4",
-    "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1",
-    "vite-plugin-svgr": "^4.5.0"
+    "@vercel/node": "^5.6.22",
+    "@vitejs/plugin-react": "^6.0.1",
+    "tailwindcss": "^4.2.2",
+    "typescript": "^6.0.2",
+    "vite": "^8.0.3",
+    "vite-plugin-svgr": "^5.0.0"
   }
 }

--- a/src/components/home/FeaturedLinks.tsx
+++ b/src/components/home/FeaturedLinks.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { FiChevronRight, FiFolder, FiMail } from "react-icons/fi";
 import { useWebHaptics } from "web-haptics/react";
 import { FEATURED_LINKS } from "@/lib/constants";
+import { prefetchProjects } from "@/lib/projectsCache";
 import translate from "@/i18n/translate";
 import { cn } from "@/lib/utils";
 
@@ -31,8 +32,14 @@ const itemVariants: Variants = {
   },
 };
 
-export const FeaturedLinks = () => {
+export const FeaturedLinks = ({ locale }: { locale: string }) => {
   const haptic = useWebHaptics();
+
+  const handlePointerEnter = (linkId: string) => {
+    if (linkId === "projects") {
+      prefetchProjects(locale);
+    }
+  };
 
   return (
     <motion.div
@@ -43,7 +50,12 @@ export const FeaturedLinks = () => {
     >
       {FEATURED_LINKS.map((link) => (
         <motion.div key={link.id} variants={itemVariants}>
-          <Link to={link.to} className="block group" onClick={() => haptic.trigger("medium")}>
+          <Link
+            to={link.to}
+            className="block group"
+            onClick={() => haptic.trigger("medium")}
+            onPointerEnter={() => handlePointerEnter(link.id)}
+          >
             <div
               className={cn(
                 "flex items-center justify-between",

--- a/src/lib/projectsCache.ts
+++ b/src/lib/projectsCache.ts
@@ -1,0 +1,61 @@
+import { API_URLS } from "./constants";
+
+let cachedProjects: any[] | null = null;
+let cacheLocale: string | null = null;
+let fetchPromise: Promise<any[]> | null = null;
+
+async function fetchProjectsData(locale: string): Promise<any[]> {
+  const lang = locale.split("-")[0];
+
+  try {
+    const response = await fetch(`${API_URLS.projects}${lang}/projects`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!response.ok) throw new Error();
+    return await response.json();
+  } catch {
+    const fallbackResponse = await fetch(`${API_URLS.fallback}${lang}/projects`);
+    if (!fallbackResponse.ok) throw new Error();
+    return await fallbackResponse.json();
+  }
+}
+
+export function prefetchProjects(locale: string) {
+  if (cachedProjects && cacheLocale === locale) return;
+  if (fetchPromise && cacheLocale === locale) return;
+
+  cacheLocale = locale;
+  fetchPromise = fetchProjectsData(locale)
+    .then((data) => {
+      cachedProjects = data;
+      return data;
+    })
+    .catch(() => {
+      fetchPromise = null;
+      return [];
+    });
+}
+
+export function getProjectsCache(locale: string): { data: any[] | null; fetch: () => Promise<any[]> } {
+  if (cachedProjects && cacheLocale === locale) {
+    return { data: cachedProjects, fetch: () => Promise.resolve(cachedProjects!) };
+  }
+
+  if (fetchPromise && cacheLocale === locale) {
+    return { data: null, fetch: () => fetchPromise! };
+  }
+
+  cacheLocale = locale;
+  fetchPromise = fetchProjectsData(locale).then((data) => {
+    cachedProjects = data;
+    return data;
+  });
+
+  return { data: null, fetch: () => fetchPromise! };
+}
+
+export function invalidateProjectsCache() {
+  cachedProjects = null;
+  cacheLocale = null;
+  fetchPromise = null;
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -39,7 +39,7 @@ export const HomePage = ({ locale, onLocaleChange }: HomePageProps) => {
         <div className="flex-1 flex flex-col justify-center py-4 sm:py-8">
           <ProfileSection />
           <SocialGrid />
-          <FeaturedLinks />
+          <FeaturedLinks locale={locale} />
         </div>
 
         {/* Footer */}

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -6,7 +6,7 @@ import { useWebHaptics } from "web-haptics/react";
 import { PageLayout } from "@/components/layout";
 import { ProjectCard } from "@/components/projects";
 import { LoadingSpinner, ThemeToggle, LanguageToggle } from "@/components/shared";
-import { API_URLS } from "@/lib/constants";
+import { getProjectsCache } from "@/lib/projectsCache";
 import translate from "@/i18n/translate";
 import useDocumentTitle from "@/hooks/useDocumentTitle";
 import { cn } from "@/lib/utils";
@@ -32,34 +32,29 @@ export const ProjectsPage = ({ locale, onLocaleChange }: ProjectsPageProps) => {
   }, []);
 
   useEffect(() => {
-    const fetchProjects = async () => {
+    const loadProjects = async () => {
       setError(false);
       setLoading(true);
 
-      const lang = locale.split("-")[0];
+      const cache = getProjectsCache(locale);
+
+      if (cache.data) {
+        setProjects(cache.data);
+        setLoading(false);
+        return;
+      }
 
       try {
-        const response = await fetch(`${API_URLS.projects}${lang}/projects`, {
-          signal: AbortSignal.timeout(5000),
-        });
-        if (!response.ok) throw new Error();
-        setProjects(await response.json());
+        const data = await cache.fetch();
+        setProjects(data);
       } catch {
-        try {
-          const fallbackResponse = await fetch(
-            `${API_URLS.fallback}${lang}/projects`
-          );
-          if (!fallbackResponse.ok) throw new Error();
-          setProjects(await fallbackResponse.json());
-        } catch {
-          setError(true);
-        }
+        setError(true);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchProjects();
+    loadProjects();
   }, [locale]);
 
   useEffect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,9 +22,13 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ["react", "react-dom", "react-router-dom"],
-          animations: ["framer-motion"],
+        manualChunks(id) {
+          if (id.includes("node_modules/react-dom") || id.includes("node_modules/react/") || id.includes("node_modules/react-router-dom")) {
+            return "vendor";
+          }
+          if (id.includes("node_modules/framer-motion")) {
+            return "animations";
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary
- Updates all dependencies to latest versions (Vite 8, TypeScript 6, react-intl 10, @vitejs/plugin-react 6, vite-plugin-svgr 5)
- Fixes Vite 8 build failure: `manualChunks` converted from object to function (Rolldown replaces Rollup)
- Fixes TypeScript 6 build failure: removes deprecated `baseUrl` from tsconfig
- Changes Dependabot to monthly schedule with a single grouped PR
- Adds prefetch on hover: pointing at the projects link preloads API data in the background so the page loads instantly

Supersedes #51 which failed at Vercel build due to breaking changes in the major version bumps.

## Test plan
- [ ] Verify Vercel preview deployment builds and deploys successfully
- [ ] Navigate to homepage and hover the projects link, then click — should load with no/minimal spinner
- [ ] Confirm all pages render correctly with updated dependencies