### PR TITLE
feat: wider contact page layout on desktop

### DIFF
--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -147,7 +147,7 @@ export const ContactPage = ({ locale, onLocaleChange }: ContactPageProps) => {
   const isDisabled = status === "submitting";
 
   return (
-    <PageLayout maxWidth="sm">
+    <PageLayout maxWidth="md">
       {/* Header */}
       <motion.div
         className="flex justify-between items-center mb-6"
@@ -254,7 +254,7 @@ export const ContactPage = ({ locale, onLocaleChange }: ContactPageProps) => {
               <textarea
                 id="message"
                 name="message"
-                rows={4}
+                rows={6}
                 placeholder={intl.formatMessage({
                   id: "app.contact.messagePlaceholder",
                 })}


### PR DESCRIPTION
## Summary
- Widens contact page from `max-w-md` (448px) to `max-w-2xl` (672px) to match the projects page feel on desktop
- Increases message textarea from 4 to 6 rows for more writing space

## Test plan
- [ ] Check contact page on desktop — form should feel less cramped
- [ ] Check contact page on mobile — should still look good (responsive)
- [ ] Submit a test message to verify form still works