### PR TITLE
fix: full-height + dark theme in iOS 26 Safari and IG in-app browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
         <meta name="author" content="Alexis Provost">
         <meta name="uptime" content="A Piece of Cake" />
         <meta name="color-scheme" content="light dark">
+        <meta name="theme-color" content="#FAFAFA" media="(prefers-color-scheme: light)">
+        <meta name="theme-color" content="#09090B" media="(prefers-color-scheme: dark)">
         <meta name="darkreader-lock">
 
         <!-- The Open Graph protocol -->

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -24,7 +24,7 @@ export const PageLayout = ({
   return (
     <main
       className={cn(
-        "min-h-screen min-h-svh w-full px-4 py-8 sm:px-6 lg:px-8",
+        "min-h-screen min-h-dvh w-full px-4 py-8 sm:px-6 lg:px-8",
         "bg-sand transition-colors duration-300",
         "[html[data-theme='dark']_&]:bg-warm-black",
         centered && "flex flex-col items-center",

--- a/src/components/layout/PageTransition.tsx
+++ b/src/components/layout/PageTransition.tsx
@@ -34,7 +34,7 @@ export const PageTransition = ({ children }: PageTransitionProps) => {
       initial="initial"
       animate="animate"
       exit="exit"
-      className="min-h-screen"
+      className="min-h-screen min-h-dvh"
     >
       {children}
     </motion.div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ export const HomePage = ({ locale, onLocaleChange }: HomePageProps) => {
   return (
     <main
       className={cn(
-        "min-h-screen min-h-svh w-full",
+        "min-h-screen min-h-dvh w-full",
         "flex flex-col",
         "px-5 sm:px-6 py-6 sm:py-8",
         "bg-sand [html[data-theme='dark']_&]:bg-warm-black"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,6 +16,11 @@
     overflow-x: hidden;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    background-color: var(--color-sand);
+  }
+
+  :root[data-theme="dark"] {
+    background-color: var(--color-warm-black);
   }
 
   body {
@@ -23,8 +28,7 @@
     transition: background-color 0.2s ease, color 0.2s ease;
     overflow-x: hidden;
     min-height: 100vh;
-    min-height: 100svh;
-    min-height: -webkit-fill-available;
+    min-height: 100dvh;
   }
 
   :root[data-theme="dark"] body {
@@ -39,8 +43,7 @@
   #root {
     overflow-x: hidden;
     min-height: 100vh;
-    min-height: 100svh;
-    min-height: -webkit-fill-available;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
   }


### PR DESCRIPTION
## Summary
- Replace `100vh`/`100svh` with `100dvh` so pages track the dynamic viewport when in-app browser toolbars expand or collapse (fixes the page not filling height in Instagram's in-app Safari on iOS 26).
- Set `html` background-color to match the theme so overscroll and safe-area regions stay dark in dark mode (fixes the white strip at the top).
- Add `theme-color` meta tags with `prefers-color-scheme` media queries for older iOS versions that still honor them.